### PR TITLE
fix: YES/NO pre-selection and post-bet feedback

### DIFF
--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -22,11 +22,12 @@ interface BetModalProps {
   isOpen: boolean;
   onClose: () => void;
   onBetPlaced?: () => void;
+  initialOutcome?: "yes" | "no";
 }
 
-export function BetModal({ market, isOpen, onClose, onBetPlaced }: BetModalProps) {
+export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome }: BetModalProps) {
   const { publicKey, requestTransaction, transactionStatus } = useWallet();
-  const [outcome, setOutcome] = useState<"yes" | "no">("yes");
+  const [outcome, setOutcome] = useState<"yes" | "no">(initialOutcome ?? "yes");
   const [amount, setAmount] = useState("");
   const [balance, setBalance] = useState<bigint | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
@@ -282,13 +283,19 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced }: BetModalProps
           )}
 
           {state === "confirmed" && (
-            <button
-              type="button"
-              onClick={handleClose}
-              className="w-full py-3 bg-emerald-600 hover:bg-emerald-700 rounded-xl text-white font-bold transition-colors"
-            >
-              Done
-            </button>
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="w-full py-3 bg-emerald-600 hover:bg-emerald-700 rounded-xl text-white font-bold transition-colors"
+              >
+                Done
+              </button>
+              <p className="text-xs text-gray-500 text-center flex items-center justify-center gap-1.5">
+                <span className="css-spinner-sm" />
+                Pool data will update in a few moments
+              </p>
+            </div>
           )}
 
           {isExecuting && (

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -17,7 +17,7 @@ interface Market {
 
 interface MarketCardProps {
   market: Market;
-  onBet: () => void;
+  onBet: (outcome: "yes" | "no") => void;
   onClaim?: () => void;
   onRefund?: () => void;
   onResolve?: () => void;
@@ -93,7 +93,7 @@ export function MarketCard({ market, onBet, onClaim, onRefund, onResolve, userPo
       {isOpen && connected && (
         <div className="grid grid-cols-2 gap-2 mb-3">
           <button
-            onClick={onBet}
+            onClick={() => onBet("yes")}
             className="flex items-center justify-between px-3 py-2.5 rounded-md bg-emerald-500/10 border-2 border-emerald-500/15 hover:border-emerald-500/40 transition-colors group"
           >
             <span className="text-emerald-400 text-sm font-bold">Yes</span>
@@ -102,7 +102,7 @@ export function MarketCard({ market, onBet, onClaim, onRefund, onResolve, userPo
             </span>
           </button>
           <button
-            onClick={onBet}
+            onClick={() => onBet("no")}
             className="flex items-center justify-between px-3 py-2.5 rounded-md bg-rose-500/10 border-2 border-rose-500/15 hover:border-rose-500/40 transition-colors group"
           >
             <span className="text-rose-400 text-sm font-bold">No</span>

--- a/frontend/src/components/MarketList.tsx
+++ b/frontend/src/components/MarketList.tsx
@@ -27,6 +27,7 @@ export function MarketList() {
     null
   );
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
+  const [selectedOutcome, setSelectedOutcome] = useState<"yes" | "no">("yes");
 
   // Store raw chain data for claim calculations
   const [chainMarkets, setChainMarkets] = useState<MarketData[]>([]);
@@ -71,8 +72,9 @@ export function MarketList() {
     return positions.find((p) => p.marketId === marketId) ?? null;
   };
 
-  const handleBet = (market: DisplayMarket) => {
+  const handleBet = (market: DisplayMarket, outcome: "yes" | "no") => {
     setSelectedMarket(market);
+    setSelectedOutcome(outcome);
     setActiveModal("bet");
   };
 
@@ -182,7 +184,7 @@ export function MarketList() {
             <div key={market.id} className="market-card-item">
             <MarketCard
               market={market}
-              onBet={() => handleBet(market)}
+              onBet={(outcome) => handleBet(market, outcome)}
               onClaim={() => handleClaim(market)}
               onRefund={() => handleRefund(market)}
               onResolve={() => handleResolve(market)}
@@ -220,6 +222,7 @@ export function MarketList() {
           isOpen={true}
           onClose={handleModalClose}
           onBetPlaced={handleBetPlaced}
+          initialOutcome={selectedOutcome}
         />
       )}
 

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -46,6 +46,7 @@ export function MarketDetailPage() {
   const { marketId } = useParams<{ marketId: string }>();
   const { connected } = useWallet();
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
+  const [selectedOutcome, setSelectedOutcome] = useState<"yes" | "no">("yes");
   const pageRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -274,7 +275,7 @@ export function MarketDetailPage() {
               <h3 className="text-xs sm:text-sm font-bold text-gray-400 uppercase tracking-wider mb-3 sm:mb-4">Place a Bet</h3>
               <div className="space-y-3">
                 <button
-                  onClick={() => setActiveModal("bet")}
+                  onClick={() => { setSelectedOutcome("yes"); setActiveModal("bet"); }}
                   className="w-full flex items-center justify-between px-4 py-3 rounded-md bg-emerald-500/10 border-2 border-emerald-500/15 hover:border-emerald-500/40 transition-colors group"
                 >
                   <span className="text-emerald-400 font-bold">Yes</span>
@@ -283,7 +284,7 @@ export function MarketDetailPage() {
                   </span>
                 </button>
                 <button
-                  onClick={() => setActiveModal("bet")}
+                  onClick={() => { setSelectedOutcome("no"); setActiveModal("bet"); }}
                   className="w-full flex items-center justify-between px-4 py-3 rounded-md bg-rose-500/10 border-2 border-rose-500/15 hover:border-rose-500/40 transition-colors group"
                 >
                   <span className="text-rose-400 font-bold">No</span>
@@ -409,6 +410,7 @@ export function MarketDetailPage() {
           isOpen={true}
           onClose={handleModalClose}
           onBetPlaced={() => refetchPositions()}
+          initialOutcome={selectedOutcome}
         />
       )}
 


### PR DESCRIPTION
## Summary
- YES/NO buttons on market cards now pass the selected outcome to the bet modal (was always defaulting to YES)
- Added pool refresh indicator after bet confirmation so users know data is updating

## Test plan
- [x] Build passes
- [x] Lint passes  
- [x] 55/55 tests pass
- [ ] Click NO on market card → modal opens with NO pre-selected
- [ ] Click YES on market card → modal opens with YES pre-selected
- [ ] After bet confirms, spinner + "Pool data will update" message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)