### PR TITLE
fix: correct privacy claims across all UI components

### DIFF
--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -258,8 +258,8 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
             </svg>
             <span>
-              Your bet is private — direction, amount, and identity are encrypted
-              as Aleo records. Only pool totals are public.
+              Your bet is private — direction and identity are encrypted
+              as Aleo records. Bet amount and pool totals are public.
             </span>
           </div>
 

--- a/frontend/src/components/HeroSection.tsx
+++ b/frontend/src/components/HeroSection.tsx
@@ -82,7 +82,7 @@ export function HeroSection() {
               {/* Rows */}
               {([
                 ["Bet direction", true, false],
-                ["Bet amount", true, false],
+                ["Bet amount", true, true],
                 ["Wallet link", true, false],
                 ["Pool totals", true, true],
                 ["Market outcome", true, true],

--- a/frontend/src/components/HowItWorksModal.tsx
+++ b/frontend/src/components/HowItWorksModal.tsx
@@ -35,7 +35,7 @@ const slides = [
     description:
       "Bet with Aleo credits. Your transaction generates a zero-knowledge proof — so only aggregate pool totals are public.",
     privacy:
-      "Your bet amount and wallet identity stay hidden from everyone.",
+      "Your bet direction and wallet identity stay hidden from everyone. Only the amount and pool totals are public.",
     icon: (
       <div className="flex flex-col items-center gap-3">
         <div className="glass-card px-6 py-4 flex flex-col items-center gap-1 relative">

--- a/frontend/src/components/MarketHistory.tsx
+++ b/frontend/src/components/MarketHistory.tsx
@@ -235,8 +235,8 @@ export function MarketHistory({
                 </svg>
                 <div className="space-y-2">
                   <p className="text-sm text-gray-300">
-                    All bets in this market are private. Bet direction, amount, and wallet
-                    identity are encrypted as Aleo records.
+                    All bets in this market are private. Bet direction and wallet
+                    identity are encrypted as Aleo records. Bet amount is public.
                   </p>
                   <p className="text-xs text-gray-500">
                     Only aggregate pool totals and market outcomes are public. Your position

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -255,8 +255,8 @@ export function MarketDetailPage() {
               </svg>
               <div className="space-y-2">
                 <p className="text-sm text-gray-300">
-                  All bets in this market are private. Bet direction, amount, and wallet
-                  identity are encrypted as Aleo records.
+                  All bets in this market are private. Bet direction and wallet
+                  identity are encrypted as Aleo records. Bet amount is public.
                 </p>
                 <p className="text-xs text-gray-500">
                   Only aggregate pool totals and market outcomes are public. Your position


### PR DESCRIPTION
## Summary
- Bet amount is a public transition input, not private
- Fixed 5 components that incorrectly claimed amount was encrypted/private:
  - HeroSection privacy comparison table
  - BetModal privacy notice
  - HowItWorksModal step 2
  - MarketHistory privacy section
  - MarketDetailPage privacy section

🤖 Generated with [Claude Code](https://claude.com/claude-code)