### PR TITLE
fix: correct privacy model across all UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <h1 align="center">Private Prediction Market</h1>
-    <p align="center">A parimutuel prediction market on Aleo where bet positions are private and pool totals are public.</p>
+    <p align="center">A parimutuel prediction market on Aleo where bettor identity is private and pool totals are public.</p>
 </p>
 
 <p align="center">
@@ -44,7 +44,7 @@
 
 ## 1. Overview
 
-Users bet on binary (YES/NO) outcomes. Credits are pooled per side. After resolution, winners split the opposing pool proportionally, minus a 2% fee. Bet records are private Aleo records — the chain reveals pool totals but not who bet on which side.
+Users bet on binary (YES/NO) outcomes. Credits are pooled per side. After resolution, winners split the opposing pool proportionally, minus a 2% fee. Bet records are encrypted Aleo records — the chain reveals bet direction, amount, and pool totals, but not which wallet placed a given bet.
 
 The contract is deployed on Aleo Testnet Beta as `prediction_market_test004.aleo`. It depends on `credits.aleo` for native credit transfers and `official_oracle_v2.aleo` for attested data feeds.
 
@@ -75,14 +75,18 @@ The frontend generates ZK proofs client-side via `@provablehq/sdk` WASM workers.
 | Market existence, status, outcome | Public | On-chain mappings |
 | Pool totals (YES/NO aggregate) | Public | On-chain mappings |
 | Market end time, creator address | Public | On-chain mappings |
-| Bet direction (YES or NO) | **Private** | Aleo record (owner only) |
-| Bettor identity | **Private** | Aleo record (owner only) |
-| Individual bet amount | **Public** | On-chain (transition input) |
+| Bet direction (YES or NO) | **Public** | Finalize arguments (on-chain) |
+| Individual bet amount | **Public** | Transition input (on-chain) |
+| Bettor identity (wallet address) | **Private** | Not in finalize args; encrypted in Bet record |
 | Payout amount per user | **Private until claim** | Revealed at claim time |
 
-Pool totals are public because parimutuel payout calculation requires them. When a user places a bet, the aggregate pool for one side increases, but the chain does not record which address caused the increase. The `Bet` record is stored encrypted on-chain; only the record owner can decrypt it.
+**What is private**: The bettor's wallet address is never linked to a bet in finalize arguments or public mappings. An observer can see "someone bet YES with 10,000 microcredits on market 3" but cannot determine which address placed it. The `Bet` record containing the owner address is stored encrypted on-chain; only the record owner can decrypt it.
 
-**Limitation**: Because pool updates happen in the finalize block, an observer watching pool deltas at the block level could infer bet direction from timing. This is an accepted tradeoff for the current design. Commit-reveal patterns could mitigate this in a future version.
+**What is public**: Bet direction is passed to the finalize block (which updates either `yes_pool` or `no_pool`), so it appears in plaintext in the transaction's future output. Bet amount is a public transition input. This is an inherent constraint — finalize arguments on Aleo are always public.
+
+**Why this matters**: On EVM prediction markets, every trade is linked to a wallet address. Participants can be identified, front-run, and profiled. On Aleo, the identity link is broken — you cannot build a profile of who bet what. The privacy guarantee is **anonymity**, not bet secrecy.
+
+**Limitation**: A commit-reveal pattern could also hide bet direction by batching reveals, breaking timing correlation between individual bets and pool changes. This is planned for a future version.
 
 ### 2.2 Parimutuel Mechanics
 
@@ -227,7 +231,7 @@ A `Bet` record is created by `place_bet` or `add_to_bet`, and consumed (spent) b
 
 | Transition | Privacy | Description |
 |-----------|---------|-------------|
-| `place_bet(market_id, outcome, amount)` | outcome is **private** | Place a new bet. Returns a `Bet` record. Transfers credits via `credits.aleo/transfer_public_as_signer`. |
+| `place_bet(market_id, outcome, amount)` | bettor identity is **private** | Place a new bet. Returns a `Bet` record. Outcome is a private transition input but becomes public in finalize args. Transfers credits via `credits.aleo/transfer_public_as_signer`. |
 | `add_to_bet(existing_bet, additional_amount)` | bet record is **private** | Consolidate additional funds into an existing bet. Consumes old record, returns new one with combined amount. |
 | `claim_winnings(bet, claimed_amount)` | bet record is **private** | Claim payout after resolution. Contract verifies the claimed amount. Consumes the record. |
 | `claim_refund(bet)` | bet record is **private** | Full refund for cancelled markets. Consumes the record. |

--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -258,8 +258,8 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
             </svg>
             <span>
-              Your bet is private — direction and identity are encrypted
-              as Aleo records. Bet amount and pool totals are public.
+              Your bet is anonymous — your wallet address is never linked to
+              the bet on-chain. Direction, amount, and pool totals are public.
             </span>
           </div>
 

--- a/frontend/src/components/HeroSection.tsx
+++ b/frontend/src/components/HeroSection.tsx
@@ -39,7 +39,7 @@ export function HeroSection() {
 
             <p className="hero-subtitle text-gray-400 text-base sm:text-lg leading-relaxed mb-6 sm:mb-10 max-w-md">
               A prediction market on Aleo where zero-knowledge proofs keep your
-              positions hidden while pools stay transparent.
+              identity hidden while pools stay transparent.
             </p>
 
             <div className="flex flex-wrap gap-2 sm:gap-3">
@@ -47,7 +47,7 @@ export function HeroSection() {
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
                   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                 </svg>
-                Private Bets
+                Anonymous Bets
               </span>
               <span className="hero-pill inline-flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm bg-navy-800 border-2 border-navy-600 rounded-md px-3 sm:px-4 py-2 sm:py-2.5 text-gray-300 font-medium">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
@@ -81,9 +81,9 @@ export function HeroSection() {
 
               {/* Rows */}
               {([
-                ["Bet direction", true, false],
+                ["Bettor identity", true, false],
+                ["Bet direction", true, true],
                 ["Bet amount", true, true],
-                ["Wallet link", true, false],
                 ["Pool totals", true, true],
                 ["Market outcome", true, true],
               ] as const).map(([label, otherVisible, thisVisible]) => (
@@ -134,8 +134,8 @@ export function HeroSection() {
 
             <div className="mt-4 sm:mt-5 pt-3 sm:pt-4 border-t-2 border-navy-600 text-center">
               <p className="text-[11px] sm:text-xs text-gray-500">
-                Bet positions are encrypted as Aleo records. Only aggregate pool
-                totals are public.
+                Your wallet address is never linked to your bet on-chain.
+                Bet direction and amount are public; bettor identity is not.
               </p>
             </div>
           </div>

--- a/frontend/src/components/HowItWorksModal.tsx
+++ b/frontend/src/components/HowItWorksModal.tsx
@@ -15,7 +15,7 @@ const slides = [
     description:
       "Browse prediction markets and choose Yes or No based on what you think will happen. Odds shift as others bet.",
     privacy:
-      "On Aleo, your bet direction is encrypted — no one can see which side you picked.",
+      "On Aleo, your wallet address is never linked to your bet — no one can see who placed it.",
     icon: (
       <div className="flex gap-3 items-center justify-center">
         <div className="glass-card px-5 py-4 flex flex-col items-center gap-2 w-28">
@@ -31,11 +31,11 @@ const slides = [
   },
   {
     step: "2",
-    title: "Place a Private Bet",
+    title: "Place an Anonymous Bet",
     description:
       "Bet with Aleo credits. Your transaction generates a zero-knowledge proof — so only aggregate pool totals are public.",
     privacy:
-      "Your bet direction and wallet identity stay hidden from everyone. Only the amount and pool totals are public.",
+      "Your wallet identity stays hidden — no one can link your address to a bet. Direction and amount are visible, but not who placed it.",
     icon: (
       <div className="flex flex-col items-center gap-3">
         <div className="glass-card px-6 py-4 flex flex-col items-center gap-1 relative">

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -168,7 +168,7 @@ export function MarketCard({ market, onBet, onClaim, onRefund, onResolve, userPo
           <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
           </svg>
-          Private
+          Anonymous
         </div>
         <div className="flex items-center gap-3 text-[11px] text-gray-600">
           <span className="font-mono">{totalPoolFormatted} credits</span>

--- a/frontend/src/components/MarketHistory.tsx
+++ b/frontend/src/components/MarketHistory.tsx
@@ -235,12 +235,12 @@ export function MarketHistory({
                 </svg>
                 <div className="space-y-2">
                   <p className="text-sm text-gray-300">
-                    All bets in this market are private. Bet direction and wallet
-                    identity are encrypted as Aleo records. Bet amount is public.
+                    All bets in this market are anonymous. Your wallet address is
+                    never linked to a bet on-chain. Direction and amount are public.
                   </p>
                   <p className="text-xs text-gray-500">
-                    Only aggregate pool totals and market outcomes are public. Your position
-                    is only visible to you through your wallet.
+                    Pool totals, bet direction, and outcomes are public. Your identity
+                    as a bettor is private — only you can prove you placed a bet via your encrypted record.
                   </p>
                 </div>
               </div>

--- a/frontend/src/components/TransactionProgress.tsx
+++ b/frontend/src/components/TransactionProgress.tsx
@@ -81,7 +81,7 @@ export function TransactionProgress({
       {/* Explanation */}
       {state === "proving" && (
         <p className="text-xs text-gray-500">
-          ZK proofs ensure your bet remains private. This computation runs
+          ZK proofs ensure your bet remains anonymous. This computation runs
           locally on your device.
         </p>
       )}

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -255,12 +255,12 @@ export function MarketDetailPage() {
               </svg>
               <div className="space-y-2">
                 <p className="text-sm text-gray-300">
-                  All bets in this market are private. Bet direction and wallet
-                  identity are encrypted as Aleo records. Bet amount is public.
+                  All bets in this market are anonymous. Your wallet address is
+                  never linked to a bet on-chain. Direction and amount are public.
                 </p>
                 <p className="text-xs text-gray-500">
-                  Only aggregate pool totals and market outcomes are public. Your position
-                  is only visible to you through your wallet.
+                  Pool totals, bet direction, and outcomes are public. Your identity
+                  as a bettor is private — only you can prove you placed a bet via your encrypted record.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Finalize arguments on Aleo are always public. Bet direction is passed to finalize (to update the correct pool), so it's visible in the transaction's future output. The actual privacy guarantee is **anonymity** — the bettor's wallet address is never linked to a bet on-chain.

**Files updated (8):**
- README.md — privacy table, overview, transitions table
- HeroSection — comparison table now shows "Bettor identity" as the private row
- HowItWorksModal — corrected privacy callouts
- BetModal — privacy notice
- MarketCard — "Private" → "Anonymous"
- MarketHistory — privacy section
- MarketDetailPage — privacy section
- TransactionProgress — proving explanation

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Verify HeroSection table shows identity as private, direction/amount as public
- [ ] Verify BetModal says "anonymous" not "private"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy messaging across the app to clarify the anonymity model: wallet addresses are never linked to on-chain bets, while bet direction and amount remain public.
  * Renamed "Private Bets" to "Anonymous Bets" throughout the interface.
  * Revised privacy explanations in documentation and help sections to accurately reflect the updated privacy guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->