### PR TITLE
feat: Wave 3 — USDCx stablecoin integration

### DIFF
--- a/contracts/prediction_market/program.json
+++ b/contracts/prediction_market/program.json
@@ -1,20 +1,14 @@
 {
-  "program": "prediction_market_test007.aleo",
+  "program": "prediction_market_usdcx_v1.aleo",
   "version": "0.1.0",
-  "description": "Private prediction market with parimutuel betting",
+  "description": "Private prediction market with USDCx stablecoin",
   "license": "MIT",
   "leo": "3.4.0",
   "dependencies": [
-    {
-      "name": "credits.aleo",
-      "location": "network",
-      "network": "testnetbeta"
-    },
-    {
-      "name": "official_oracle_v2.aleo",
-      "location": "network",
-      "network": "testnetbeta"
-    }
-  ],
-  "dev_dependencies": null
+    { "name": "merkle_tree.aleo", "location": "network", "network": "testnetbeta" },
+    { "name": "test_usdcx_multisig_core.aleo", "location": "network", "network": "testnetbeta" },
+    { "name": "test_usdcx_freezelist.aleo", "location": "network", "network": "testnetbeta" },
+    { "name": "test_usdcx_stablecoin.aleo", "location": "network", "network": "testnetbeta" },
+    { "name": "official_oracle_v2.aleo", "location": "network", "network": "testnetbeta" }
+  ]
 }

--- a/contracts/prediction_market/src/main.leo
+++ b/contracts/prediction_market/src/main.leo
@@ -3,10 +3,10 @@
 // Bet positions are fully private — pool totals only published at resolution
 // No individual bet direction or amount appears in finalize args
 
-import credits.aleo;
+import test_usdcx_stablecoin.aleo;
 import official_oracle_v2.aleo;
 
-program prediction_market_test007.aleo {
+program prediction_market_usdcx_v1.aleo {
     // ========================================
     // HELPER FUNCTIONS (Truly Homomorphic Commitments)
     // ========================================
@@ -35,17 +35,17 @@ program prediction_market_test007.aleo {
     const STATUS_DISPUTED: u8 = 4u8;
 
     // Limits
-    const MIN_BET: u64 = 1000u64; // 0.001 credits minimum
+    const MIN_BET: u128 = 1_000_000u128; // $1 USDC minimum (6 decimals)
 
     // Fee in basis points (2% = 200 bps)
-    const FEE_BPS: u64 = 200u64;
+    const FEE_BPS: u128 = 200u128;
 
     // Fixed denomination betting tiers (Concern 3: hide exact bet sizes)
-    const TIER_1: u64 = 1000u64;
-    const TIER_2: u64 = 5000u64;
-    const TIER_3: u64 = 10000u64;
-    const TIER_4: u64 = 50000u64;
-    const TIER_5: u64 = 100000u64;
+    const TIER_1: u128 = 1_000_000u128;    // $1
+    const TIER_2: u128 = 5_000_000u128;    // $5
+    const TIER_3: u128 = 10_000_000u128;   // $10
+    const TIER_4: u128 = 50_000_000u128;   // $50
+    const TIER_5: u128 = 100_000_000u128;  // $100
 
     // Dispute window: ~1000 blocks after resolution
     const DISPUTE_BLOCKS: u32 = 1000u32;
@@ -69,7 +69,7 @@ program prediction_market_test007.aleo {
         owner: address,
         market_id: field,
         outcome: bool,      // true = YES, false = NO — PRIVATE, never appears in finalize
-        amount: u64,        // PRIVATE, never appears in finalize
+        amount: u128,       // PRIVATE, never appears in finalize
         nonce_value: u128,  // Random nonce for commitment hiding (2^128 search space)
     }
 
@@ -81,8 +81,8 @@ program prediction_market_test007.aleo {
     mapping market_status: field => u8;
 
     // Pool totals per market — ONLY SET AT RESOLUTION, not during betting
-    mapping yes_pool: field => u64;
-    mapping no_pool: field => u64;
+    mapping yes_pool: field => u128;
+    mapping no_pool: field => u128;
 
     // Resolved outcome (true=YES won, false=NO won)
     mapping market_outcome: field => bool;
@@ -91,7 +91,7 @@ program prediction_market_test007.aleo {
     mapping admin: bool => address;
 
     // Collected fees per market (for admin withdrawal)
-    mapping collected_fees: field => u64;
+    mapping collected_fees: field => u128;
 
     // Whether fees have been withdrawn for a market
     mapping fees_withdrawn: field => bool;
@@ -115,7 +115,7 @@ program prediction_market_test007.aleo {
     mapping operator: bool => address;
 
     // Running fee estimate per market (for frontend display, updated at resolution)
-    mapping estimated_fees: field => u64;
+    mapping estimated_fees: field => u128;
 
     // Market registry: total number of markets created (singleton: true => count)
     mapping market_count: bool => u64;
@@ -234,8 +234,8 @@ program prediction_market_test007.aleo {
     async transition resolve_market(
         public market_id: field,
         public outcome: bool,
-        public total_yes: u64,
-        public total_no: u64,
+        public total_yes: u128,
+        public total_no: u128,
         public sum_blinding_yes: scalar,
         public sum_blinding_no: scalar
     ) -> Future {
@@ -245,8 +245,8 @@ program prediction_market_test007.aleo {
     async function finalize_resolve_market(
         market_id: field,
         outcome: bool,
-        total_yes: u64,
-        total_no: u64,
+        total_yes: u128,
+        total_no: u128,
         sum_blinding_yes: scalar,
         sum_blinding_no: scalar,
         caller: address
@@ -274,8 +274,8 @@ program prediction_market_test007.aleo {
         Mapping::set(no_pool, market_id, total_no);
 
         // Calculate and store fees
-        let total_pool: u64 = total_yes + total_no;
-        let fee_amount: u64 = (total_pool * FEE_BPS) / 10000u64;
+        let total_pool: u128 = total_yes + total_no;
+        let fee_amount: u128 = (total_pool * FEE_BPS) / 10000u128;
         Mapping::set(collected_fees, market_id, fee_amount);
         Mapping::set(estimated_fees, market_id, fee_amount);
 
@@ -314,8 +314,8 @@ program prediction_market_test007.aleo {
     // Resolve market using oracle attested data + off-chain pool totals
     async transition resolve_with_oracle(
         public market_id: field,
-        public total_yes: u64,
-        public total_no: u64,
+        public total_yes: u128,
+        public total_no: u128,
         public sum_blinding_yes: scalar,
         public sum_blinding_no: scalar
     ) -> Future {
@@ -324,8 +324,8 @@ program prediction_market_test007.aleo {
 
     async function finalize_resolve_with_oracle(
         market_id: field,
-        total_yes: u64,
-        total_no: u64,
+        total_yes: u128,
+        total_no: u128,
         sum_blinding_yes: scalar,
         sum_blinding_no: scalar
     ) {
@@ -360,8 +360,8 @@ program prediction_market_test007.aleo {
         Mapping::set(yes_pool, market_id, total_yes);
         Mapping::set(no_pool, market_id, total_no);
 
-        let total_pool: u64 = total_yes + total_no;
-        let fee_amount: u64 = (total_pool * FEE_BPS) / 10000u64;
+        let total_pool: u128 = total_yes + total_no;
+        let fee_amount: u128 = (total_pool * FEE_BPS) / 10000u128;
         Mapping::set(collected_fees, market_id, fee_amount);
         Mapping::set(estimated_fees, market_id, fee_amount);
 
@@ -388,15 +388,15 @@ program prediction_market_test007.aleo {
     }
 
     // Withdraw collected fees (admin only)
-    async transition withdraw_fees(public market_id: field, public claimed_fee_amount: u64) -> Future {
-        let transfer_future: Future = credits.aleo/transfer_public(self.caller, claimed_fee_amount);
+    async transition withdraw_fees(public market_id: field, public claimed_fee_amount: u128) -> Future {
+        let transfer_future: Future = test_usdcx_stablecoin.aleo/transfer_public(self.caller, claimed_fee_amount);
         return finalize_withdraw_fees(market_id, self.caller, claimed_fee_amount, transfer_future);
     }
 
     async function finalize_withdraw_fees(
         market_id: field,
         caller: address,
-        claimed_fee_amount: u64,
+        claimed_fee_amount: u128,
         transfer: Future
     ) {
         let admin_addr: address = Mapping::get(admin, true);
@@ -408,7 +408,7 @@ program prediction_market_test007.aleo {
         let already_withdrawn: bool = Mapping::get_or_use(fees_withdrawn, market_id, false);
         assert(!already_withdrawn);
 
-        let fee_amount: u64 = Mapping::get(collected_fees, market_id);
+        let fee_amount: u128 = Mapping::get(collected_fees, market_id);
         assert_eq(claimed_fee_amount, fee_amount);
 
         // Ensure dispute window has ended before withdrawing fees
@@ -477,7 +477,7 @@ program prediction_market_test007.aleo {
         let bet_hash: field = BHP256::hash_to_field(bet);
 
         // Verify bet is valid (non-zero amount)
-        assert(bet.amount > 0u64);
+        assert(bet.amount > 0u128);
 
         return finalize_submit_bet_proof(bet.market_id, bet_hash);
     }
@@ -514,8 +514,8 @@ program prediction_market_test007.aleo {
     async transition resolve_disputed(
         public market_id: field,
         public outcome: bool,
-        public total_yes: u64,
-        public total_no: u64,
+        public total_yes: u128,
+        public total_no: u128,
         public sum_blinding_yes: scalar,
         public sum_blinding_no: scalar
     ) -> Future {
@@ -525,8 +525,8 @@ program prediction_market_test007.aleo {
     async function finalize_resolve_disputed(
         market_id: field,
         outcome: bool,
-        total_yes: u64,
-        total_no: u64,
+        total_yes: u128,
+        total_no: u128,
         sum_blinding_yes: scalar,
         sum_blinding_no: scalar,
         caller: address
@@ -553,8 +553,8 @@ program prediction_market_test007.aleo {
         Mapping::set(market_status, market_id, STATUS_RESOLVED);
 
         // Recalculate fees
-        let total_pool: u64 = total_yes + total_no;
-        let fee_amount: u64 = (total_pool * FEE_BPS) / 10000u64;
+        let total_pool: u128 = total_yes + total_no;
+        let fee_amount: u128 = (total_pool * FEE_BPS) / 10000u128;
         Mapping::set(collected_fees, market_id, fee_amount);
         Mapping::set(estimated_fees, market_id, fee_amount);
 
@@ -576,7 +576,7 @@ program prediction_market_test007.aleo {
     async transition place_bet(
         public market_id: field,
         private outcome: bool,
-        public amount: u64,
+        public amount: u128,
         private nonce_value: u128
     ) -> (Bet, Future) {
         assert(amount >= MIN_BET);
@@ -585,9 +585,9 @@ program prediction_market_test007.aleo {
         let valid_tier: bool = (amount == TIER_1) || (amount == TIER_2) || (amount == TIER_3) || (amount == TIER_4) || (amount == TIER_5);
         assert(valid_tier);
 
-        // Transfer credits from bettor to program (public transfer)
-        let transfer_future: Future = credits.aleo/transfer_public_as_signer(
-            prediction_market_test007.aleo,
+        // Transfer USDCx from bettor to program (public transfer)
+        let transfer_future: Future = test_usdcx_stablecoin.aleo/transfer_public_as_signer(
+            prediction_market_usdcx_v1.aleo,
             amount
         );
 
@@ -605,8 +605,8 @@ program prediction_market_test007.aleo {
         let blinding_no: scalar = (nonce_value + 1u128) as scalar;
 
         // Conditional amounts (ZK-hidden — observer can't tell which is real)
-        let yes_amount: u64 = outcome ? amount : 0u64;
-        let no_amount: u64 = outcome ? 0u64 : amount;
+        let yes_amount: u128 = outcome ? amount : 0u128;
+        let no_amount: u128 = outcome ? 0u128 : amount;
 
         // Pedersen commitments — BOTH are always non-zero group elements
         let yes_contrib: group = (yes_amount as scalar) * get_g() + blinding_yes * get_h();
@@ -650,15 +650,15 @@ program prediction_market_test007.aleo {
 
     // Add additional amount to an existing bet (consolidates into single record)
     // Amount must be a fixed tier (Concern 3)
-    async transition add_to_bet(existing_bet: Bet, public additional_amount: u64, private nonce_value: u128) -> (Bet, Future) {
+    async transition add_to_bet(existing_bet: Bet, public additional_amount: u128, private nonce_value: u128) -> (Bet, Future) {
         assert(additional_amount >= MIN_BET);
 
         // Concern 3: Enforce fixed denomination tiers for additional amount
         let valid_tier: bool = (additional_amount == TIER_1) || (additional_amount == TIER_2) || (additional_amount == TIER_3) || (additional_amount == TIER_4) || (additional_amount == TIER_5);
         assert(valid_tier);
 
-        let transfer_future: Future = credits.aleo/transfer_public_as_signer(
-            prediction_market_test007.aleo,
+        let transfer_future: Future = test_usdcx_stablecoin.aleo/transfer_public_as_signer(
+            prediction_market_usdcx_v1.aleo,
             additional_amount
         );
 
@@ -675,8 +675,8 @@ program prediction_market_test007.aleo {
         let blinding_no: scalar = (nonce_value + 1u128) as scalar;
 
         // Conditional amounts — only the additional amount is committed
-        let yes_amount: u64 = existing_bet.outcome ? additional_amount : 0u64;
-        let no_amount: u64 = existing_bet.outcome ? 0u64 : additional_amount;
+        let yes_amount: u128 = existing_bet.outcome ? additional_amount : 0u128;
+        let no_amount: u128 = existing_bet.outcome ? 0u128 : additional_amount;
 
         // Pedersen commitments
         let yes_contrib: group = (yes_amount as scalar) * get_g() + blinding_yes * get_h();
@@ -721,23 +721,22 @@ program prediction_market_test007.aleo {
     async transition claim_winnings(
         bet: Bet,
         public winning_outcome: bool,
-        public total_yes: u64,
-        public total_no: u64
+        public total_yes: u128,
+        public total_no: u128
     ) -> Future {
         // ZK proof: assert bet is on the winning side (private bet.outcome == public winning_outcome)
         // Losers cannot pass this assertion — they simply don't call claim_winnings
         assert(bet.outcome == winning_outcome);
 
         // Compute payout entirely in transition (private access to bet.amount)
-        let total_pool_u128: u128 = (total_yes as u128) + (total_no as u128);
-        let fee_amount_u128: u128 = (total_pool_u128 * (FEE_BPS as u128)) / 10000u128;
-        let net_pool_u128: u128 = total_pool_u128 - fee_amount_u128;
-        let winning_pool: u64 = winning_outcome ? total_yes : total_no;
-        let payout_u128: u128 = ((bet.amount as u128) * net_pool_u128) / (winning_pool as u128);
-        let payout: u64 = payout_u128 as u64;
+        let total_pool: u128 = total_yes + total_no;
+        let fee_amount: u128 = (total_pool * FEE_BPS) / 10000u128;
+        let net_pool: u128 = total_pool - fee_amount;
+        let winning_pool: u128 = winning_outcome ? total_yes : total_no;
+        let payout: u128 = (bet.amount * net_pool) / winning_pool;
 
         // Transfer payout to bet owner
-        let transfer_future: Future = credits.aleo/transfer_public(bet.owner, payout);
+        let transfer_future: Future = test_usdcx_stablecoin.aleo/transfer_public(bet.owner, payout);
 
         // Finalize only verifies public args match on-chain state
         // It never sees bet.outcome or bet.amount
@@ -753,8 +752,8 @@ program prediction_market_test007.aleo {
     async function finalize_claim_winnings(
         market_id: field,
         winning_outcome: bool,
-        total_yes: u64,
-        total_no: u64,
+        total_yes: u128,
+        total_no: u128,
         transfer: Future
     ) {
         // Verify market is resolved
@@ -769,10 +768,10 @@ program prediction_market_test007.aleo {
         let actual_outcome: bool = Mapping::get(market_outcome, market_id);
         assert_eq(winning_outcome, actual_outcome);
 
-        let actual_yes: u64 = Mapping::get(yes_pool, market_id);
+        let actual_yes: u128 = Mapping::get(yes_pool, market_id);
         assert_eq(total_yes, actual_yes);
 
-        let actual_no: u64 = Mapping::get(no_pool, market_id);
+        let actual_no: u128 = Mapping::get(no_pool, market_id);
         assert_eq(total_no, actual_no);
 
         transfer.await();
@@ -781,7 +780,7 @@ program prediction_market_test007.aleo {
     // Claim refund for cancelled market — consumes bet record, returns full amount
     // No pool data needed, no direction leaked
     async transition claim_refund(bet: Bet) -> Future {
-        let transfer_future: Future = credits.aleo/transfer_public(bet.owner, bet.amount);
+        let transfer_future: Future = test_usdcx_stablecoin.aleo/transfer_public(bet.owner, bet.amount);
 
         return finalize_claim_refund(
             bet.market_id,

--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useWallet } from "@provablehq/aleo-wallet-adaptor-react";
 import { useTransaction, stateMessages } from "../hooks/useTransaction";
 import { TransactionProgress } from "./TransactionProgress";
-import { getUsdcxBalance, getPublicBalance, formatUSDC, formatCredits, PROGRAM_ID } from "../lib/aleo";
+import { getUsdcxBalance, getPublicBalance, formatUSDC, PROGRAM_ID } from "../lib/aleo";
 import { useBetRecords } from "../hooks/useBetRecords";
 import { incrementPoolTotal, accumulateBlindings } from "../lib/supabase";
 

--- a/frontend/src/components/BetModal.tsx
+++ b/frontend/src/components/BetModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useWallet } from "@provablehq/aleo-wallet-adaptor-react";
 import { useTransaction, stateMessages } from "../hooks/useTransaction";
 import { TransactionProgress } from "./TransactionProgress";
-import { getPublicBalance, formatCredits, PROGRAM_ID } from "../lib/aleo";
+import { getUsdcxBalance, getPublicBalance, formatUSDC, formatCredits, PROGRAM_ID } from "../lib/aleo";
 import { useBetRecords } from "../hooks/useBetRecords";
 import { incrementPoolTotal, accumulateBlindings } from "../lib/supabase";
 
@@ -22,13 +22,13 @@ interface BetModalProps {
   initialOutcome?: "yes" | "no";
 }
 
-// Fixed credit tiers matching contract constants (microcredits)
+// Fixed USDC tiers matching contract constants (6 decimals)
 const TIERS = [
-  { label: "0.001", microcredits: 1000 },
-  { label: "0.005", microcredits: 5000 },
-  { label: "0.01", microcredits: 10000 },
-  { label: "0.05", microcredits: 50000 },
-  { label: "0.1", microcredits: 100000 },
+  { label: "$1", microcredits: 1_000_000 },
+  { label: "$5", microcredits: 5_000_000 },
+  { label: "$10", microcredits: 10_000_000 },
+  { label: "$50", microcredits: 50_000_000 },
+  { label: "$100", microcredits: 100_000_000 },
 ] as const;
 
 /**
@@ -39,9 +39,10 @@ const TIERS = [
 export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome }: BetModalProps) {
   const { address, executeTransaction, transactionStatus } = useWallet();
   const [outcome, setOutcome] = useState<"yes" | "no">(initialOutcome ?? "yes");
-  const [selectedTier, setSelectedTier] = useState(2); // default 0.01
+  const [selectedTier, setSelectedTier] = useState(2); // default $10
   const amount = TIERS[selectedTier].label;
   const [balance, setBalance] = useState<bigint | null>(null);
+  const [creditsBalance, setCreditsBalance] = useState<bigint | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
   const { state, error, txId, elapsed, execute, reset } = useTransaction();
   const { fetchBetRecords } = useBetRecords();
@@ -51,13 +52,14 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
   useEffect(() => {
     if (!isOpen || !address) {
       setBalance(null);
+      setCreditsBalance(null);
       return;
     }
     setBalanceLoading(true);
-    getPublicBalance(address)
-      .then(setBalance)
-      .catch(() => setBalance(null))
-      .finally(() => setBalanceLoading(false));
+    Promise.all([
+      getUsdcxBalance(address).then(setBalance).catch(() => setBalance(null)),
+      getPublicBalance(address).then(setCreditsBalance).catch(() => setCreditsBalance(null)),
+    ]).finally(() => setBalanceLoading(false));
   }, [isOpen, address]);
 
   useEffect(() => {
@@ -95,8 +97,8 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
       async () => {
         const functionName = existingRecord ? "add_to_bet" : "place_bet";
         const inputs = existingRecord
-          ? [existingRecord, `${amountMicrocredits}u64`, `${nonce}u128`]
-          : [market.id, outcome === "yes" ? "true" : "false", `${amountMicrocredits}u64`, `${nonce}u128`];
+          ? [existingRecord, `${amountMicrocredits}u128`, `${nonce}u128`]
+          : [market.id, outcome === "yes" ? "true" : "false", `${amountMicrocredits}u128`, `${nonce}u128`];
 
         const result = await executeTransaction({
           program: PROGRAM_ID,
@@ -197,7 +199,7 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
           {/* Amount tier selector */}
           <div className="mb-4">
             <label className="block text-sm text-gray-400 mb-2">
-              Amount (Credits)
+              Amount (USDC)
             </label>
             <div className="grid grid-cols-5 gap-2">
               {TIERS.map((tier, i) => (
@@ -221,9 +223,14 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
                 {balanceLoading
                   ? "Loading balance..."
                   : balance !== null
-                    ? `Available: ${formatCredits(balance)} credits`
+                    ? `Available: ${formatUSDC(balance)}`
                     : "Connect wallet to see balance"}
               </span>
+              {creditsBalance !== null && (
+                <span className="text-gray-600 text-xs">
+                  Gas: {(Number(creditsBalance) / 1_000_000).toFixed(2)} credits
+                </span>
+              )}
             </div>
             {insufficientBalance && (
               <p className="mt-1 text-sm text-rose-400">
@@ -237,7 +244,7 @@ export function BetModal({ market, isOpen, onClose, onBetPlaced, initialOutcome 
             <div className="flex justify-between text-sm">
               <span className="text-gray-400">Your Bet:</span>
               <span className="text-white font-mono">
-                {amount ? parseFloat(amount).toFixed(4) : "0.00"} credits
+                {amount} USDC
               </span>
             </div>
             <div className="flex justify-between text-sm mt-1">

--- a/frontend/src/components/ClaimModal.tsx
+++ b/frontend/src/components/ClaimModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useWallet } from "@provablehq/aleo-wallet-adaptor-react";
 import { useTransaction, stateMessages } from "../hooks/useTransaction";
 import { TransactionProgress } from "./TransactionProgress";
-import { calculatePayout, formatCredits, PROGRAM_ID } from "../lib/aleo";
+import { calculatePayout, formatUSDC, PROGRAM_ID } from "../lib/aleo";
 import { useBetRecords } from "../hooks/useBetRecords";
 import type { OnChainPosition } from "../hooks/useUserPositions";
 
@@ -141,7 +141,7 @@ export function ClaimModal({
                 <span className={winningOutcome ? "text-emerald-400" : "text-rose-400"}>
                   YES - {winningOutcome ? "Winner" : "Lost"}
                 </span>
-                <span className="text-gray-300">{formatCredits(yesAmount)} credits</span>
+                <span className="text-gray-300">{formatUSDC(yesAmount)}</span>
               </div>
             </div>
           )}
@@ -157,7 +157,7 @@ export function ClaimModal({
                 <span className={!winningOutcome ? "text-emerald-400" : "text-rose-400"}>
                   NO - {!winningOutcome ? "Winner" : "Lost"}
                 </span>
-                <span className="text-gray-300">{formatCredits(noAmount)} credits</span>
+                <span className="text-gray-300">{formatUSDC(noAmount)}</span>
               </div>
             </div>
           )}
@@ -174,7 +174,7 @@ export function ClaimModal({
             <div className="flex justify-between">
               <span className="text-gray-400 font-medium">Total Payout:</span>
               <span className="text-emerald-400 font-bold font-mono">
-                {formatCredits(totalPayout)} credits
+                {formatUSDC(totalPayout)}
               </span>
             </div>
           </div>
@@ -221,7 +221,7 @@ export function ClaimModal({
           >
             {recordsLoading
               ? "Fetching records..."
-              : `Claim ${formatCredits(totalPayout)} Credits`}
+              : `Claim ${formatUSDC(totalPayout)}`}
           </button>
         )}
 

--- a/frontend/src/components/HowItWorksModal.tsx
+++ b/frontend/src/components/HowItWorksModal.tsx
@@ -33,14 +33,14 @@ const slides = [
     step: "2",
     title: "Bet Privately with ZK",
     description:
-      "Choose from 5 fixed credit tiers. Your bet generates a ZK proof and a Pedersen commitment. Aggregate commitments update on-chain — no direction revealed. Bet amount is public but indistinguishable within tiers.",
+      "Choose from 5 fixed USDC tiers. Your bet generates a ZK proof and a Pedersen commitment. Aggregate commitments update on-chain — no direction revealed. Bet amount is public but indistinguishable within tiers.",
     privacy:
       "Bet direction is encrypted in your Bet record, never passed as a finalize argument. Pedersen commitments aggregate homomorphically so pool totals stay hidden until resolution.",
     icon: (
       <div className="flex flex-col items-center gap-3">
         <div className="glass-card px-6 py-4 flex flex-col items-center gap-1 relative">
           <span className="font-heading text-3xl text-white">Tier 3</span>
-          <span className="text-xs text-gray-500">credits</span>
+          <span className="text-xs text-gray-500">USDC</span>
           <div className="absolute -top-2 -right-2 w-6 h-6 bg-privacy/20 border-2 border-privacy/40 rounded-md flex items-center justify-center">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#D4A054" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -191,7 +191,7 @@ export function MarketCard({ market, onBet, onClaim, onRefund, onResolve, userPo
           )}
         </div>
         <div className="flex items-center gap-3 text-[11px] text-gray-600">
-          {!isOpen && <span className="font-mono">{totalPoolFormatted} credits</span>}
+          {!isOpen && <span className="font-mono">{totalPoolFormatted} in pool</span>}
           <Link
             to={`/market/${market.id}`}
             className="text-accent-light hover:text-accent transition-colors font-medium"

--- a/frontend/src/components/MarketHistory.tsx
+++ b/frontend/src/components/MarketHistory.tsx
@@ -1,7 +1,7 @@
 // Market history modal: overview, user position, privacy notice
 
 import { useMarketHistory } from "../hooks/useMarketHistory";
-import { formatCredits, MarketStatus, type MarketData } from "../lib/aleo";
+import { formatUSDC, MarketStatus, type MarketData } from "../lib/aleo";
 
 interface MarketHistoryProps {
   marketId: string;
@@ -155,7 +155,7 @@ export function MarketHistory({
                     <div className="text-xs text-gray-500 mb-1">YES Bet</div>
                     <div className="text-emerald-400 font-mono text-lg">
                       {userPosition.yesAmount > 0n
-                        ? formatCredits(userPosition.yesAmount)
+                        ? formatUSDC(userPosition.yesAmount)
                         : "-"}
                     </div>
                   </div>
@@ -163,7 +163,7 @@ export function MarketHistory({
                     <div className="text-xs text-gray-500 mb-1">NO Bet</div>
                     <div className="text-rose-400 font-mono text-lg">
                       {userPosition.noAmount > 0n
-                        ? formatCredits(userPosition.noAmount)
+                        ? formatUSDC(userPosition.noAmount)
                         : "-"}
                     </div>
                   </div>

--- a/frontend/src/components/OracleResolveModal.tsx
+++ b/frontend/src/components/OracleResolveModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useWallet } from "@provablehq/aleo-wallet-adaptor-react";
 import { useTransaction, stateMessages } from "../hooks/useTransaction";
 import { TransactionProgress } from "./TransactionProgress";
-import { PROGRAM_ID, formatCredits } from "../lib/aleo";
+import { PROGRAM_ID, formatUSDC } from "../lib/aleo";
 import { fetchBlindings } from "../lib/supabase";
 
 interface ResolveModalProps {
@@ -103,19 +103,19 @@ export function ResolveModal({
           <div className="flex justify-between text-sm">
             <span className="text-gray-400">Total Pool:</span>
             <span className="text-white font-mono">
-              {formatCredits(totalPool)} credits
+              {formatUSDC(totalPool)}
             </span>
           </div>
           <div className="flex justify-between text-sm">
             <span className="text-gray-400">YES Pool:</span>
             <span className="text-emerald-400 font-mono">
-              {formatCredits(yesPool)}
+              {formatUSDC(yesPool)}
             </span>
           </div>
           <div className="flex justify-between text-sm">
             <span className="text-gray-400">NO Pool:</span>
             <span className="text-rose-400 font-mono">
-              {formatCredits(noPool)}
+              {formatUSDC(noPool)}
             </span>
           </div>
         </div>

--- a/frontend/src/components/RefundModal.tsx
+++ b/frontend/src/components/RefundModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useWallet } from "@provablehq/aleo-wallet-adaptor-react";
 import { useTransaction, stateMessages } from "../hooks/useTransaction";
 import { TransactionProgress } from "./TransactionProgress";
-import { formatCredits, PROGRAM_ID } from "../lib/aleo";
+import { formatUSDC, PROGRAM_ID } from "../lib/aleo";
 import { useBetRecords } from "../hooks/useBetRecords";
 import type { OnChainPosition } from "../hooks/useUserPositions";
 
@@ -134,7 +134,7 @@ export function RefundModal({
             <div className="p-3 rounded-xl border border-navy-600 bg-navy-900/60">
               <div className="flex justify-between text-sm">
                 <span className="text-gray-300">YES bet</span>
-                <span className="text-gray-300">{formatCredits(yesAmount)} credits</span>
+                <span className="text-gray-300">{formatUSDC(yesAmount)}</span>
               </div>
             </div>
           )}
@@ -142,7 +142,7 @@ export function RefundModal({
             <div className="p-3 rounded-xl border border-navy-600 bg-navy-900/60">
               <div className="flex justify-between text-sm">
                 <span className="text-gray-300">NO bet</span>
-                <span className="text-gray-300">{formatCredits(noAmount)} credits</span>
+                <span className="text-gray-300">{formatUSDC(noAmount)}</span>
               </div>
             </div>
           )}
@@ -159,7 +159,7 @@ export function RefundModal({
             <div className="flex justify-between">
               <span className="text-gray-400 font-medium">Total Refund:</span>
               <span className="text-accent-light font-bold font-mono">
-                {formatCredits(totalRefund)} credits
+                {formatUSDC(totalRefund)}
               </span>
             </div>
             <p className="text-xs text-gray-500 mt-1">
@@ -210,7 +210,7 @@ export function RefundModal({
           >
             {recordsLoading
               ? "Fetching records..."
-              : `Claim Refund (${formatCredits(totalRefund)} credits)`}
+              : `Claim Refund (${formatUSDC(totalRefund)})`}
           </button>
         )}
 

--- a/frontend/src/hooks/useBetRecords.ts
+++ b/frontend/src/hooks/useBetRecords.ts
@@ -29,7 +29,7 @@ function parseRawRecord(raw: Record<string, unknown>): BetRecord | null {
 
     const marketId = String(data.market_id);
     const outcome = String(data.outcome) === "true";
-    const amountStr = String(data.amount).replace(/u64$/, "");
+    const amountStr = String(data.amount).replace(/u128$/, "").replace(/u64$/, "");
     const amount = BigInt(amountStr);
 
     return {

--- a/frontend/src/hooks/useMarketHistory.ts
+++ b/frontend/src/hooks/useMarketHistory.ts
@@ -67,7 +67,7 @@ export function useMarketHistory(
           if (recordMarketId !== normalizedMarketId) continue;
 
           const outcome = String(data.outcome) === "true";
-          const amount = BigInt(String(data.amount).replace(/u64$/, ""));
+          const amount = BigInt(String(data.amount).replace(/u128$/, "").replace(/u64$/, ""));
 
           if (outcome) {
             yesAmount += amount;

--- a/frontend/src/hooks/useUserPositions.ts
+++ b/frontend/src/hooks/useUserPositions.ts
@@ -52,7 +52,7 @@ function parseRecords(rawRecords: unknown[]): OnChainPosition[] {
       let marketId = String(data.market_id).replace(/\.private$/, "").replace(/\.public$/, "");
       if (!marketId.endsWith("field")) marketId = marketId + "field";
       const outcome = String(data.outcome).replace(/\.private$/, "") === "true";
-      const amount = BigInt(String(data.amount).replace(/u64$/, "").replace(/\.private$/, ""));
+      const amount = BigInt(String(data.amount).replace(/u128$/, "").replace(/u64$/, "").replace(/\.private$/, ""));
       const existing = byMarket.get(marketId) ?? { yes: 0n, no: 0n };
       if (outcome) existing.yes += amount;
       else existing.no += amount;

--- a/frontend/src/lib/__tests__/aleo.test.ts
+++ b/frontend/src/lib/__tests__/aleo.test.ts
@@ -14,8 +14,8 @@ import {
 
 describe("aleo utilities", () => {
   describe("PROGRAM_ID", () => {
-    it("is set to test007", () => {
-      expect(PROGRAM_ID).toBe("prediction_market_test007.aleo");
+    it("is set to usdcx_v1", () => {
+      expect(PROGRAM_ID).toBe("prediction_market_usdcx_v1.aleo");
     });
 
     it("has oracle program ID set", () => {
@@ -67,36 +67,39 @@ describe("aleo utilities", () => {
     });
   });
 
-  describe("formatCredits", () => {
-    it("formats microcredits to credits string", () => {
+  describe("formatCredits (formatUSDC)", () => {
+    it("formats micro-USDC to USDC string", () => {
       const result = formatCredits(1_000_000n);
       expect(result).toContain("1");
+      expect(result).toContain("USDC");
     });
 
     it("handles zero", () => {
       const result = formatCredits(0n);
       expect(result).toContain("0");
+      expect(result).toContain("USDC");
     });
 
     it("formats small amounts", () => {
       const result = formatCredits(1000n);
-      expect(result).toContain("0.001");
+      expect(result).toContain("0.00");
+      expect(result).toContain("USDC");
     });
   });
 
   describe("formatPool", () => {
-    it("returns 0 for zero value", () => {
-      expect(formatPool(0n)).toBe("0");
+    it("returns $0 for zero value", () => {
+      expect(formatPool(0n)).toBe("$0");
     });
 
-    it("formats values under 1000 credits", () => {
-      const result = formatPool(5_000_000n); // 5 credits
-      expect(result).toBe("5");
+    it("formats values under $1000", () => {
+      const result = formatPool(5_000_000n); // $5
+      expect(result).toBe("$5");
     });
 
     it("formats large values with k suffix", () => {
-      const result = formatPool(1_500_000_000n); // 1500 credits
-      expect(result).toBe("1.5k");
+      const result = formatPool(1_500_000_000n); // $1500
+      expect(result).toBe("$1.5k");
     });
   });
 

--- a/frontend/src/lib/aleo.ts
+++ b/frontend/src/lib/aleo.ts
@@ -7,7 +7,10 @@
 
 const API_URL = "https://api.explorer.provable.com/v1/testnet";
 /** Deployed prediction market program ID on Aleo testnet. */
-export const PROGRAM_ID = "prediction_market_test007.aleo";
+export const PROGRAM_ID = "prediction_market_usdcx_v1.aleo";
+
+/** USDCx stablecoin program ID on Aleo testnet. */
+export const USDCX_PROGRAM_ID = "test_usdcx_stablecoin.aleo";
 
 /** Market status constants matching the on-chain contract values. */
 export const MarketStatus = {
@@ -222,7 +225,7 @@ export async function isMarketExpired(marketId: string): Promise<boolean> {
   return currentHeight >= endTime;
 }
 
-/** Get public credit balance for an Aleo address. */
+/** Get public credit balance for an Aleo address (for gas). */
 export async function getPublicBalance(address: string): Promise<bigint> {
   try {
     const response = await fetch(
@@ -231,6 +234,21 @@ export async function getPublicBalance(address: string): Promise<bigint> {
     if (!response.ok) return 0n;
     const data = await response.text();
     // API returns quoted string, strip quotes before parsing
+    const cleaned = data.replace(/^"|"$/g, "");
+    return parseAleoValue(cleaned);
+  } catch {
+    return 0n;
+  }
+}
+
+/** Get USDCx balance for an Aleo address from test_usdcx_stablecoin.aleo/balances. */
+export async function getUsdcxBalance(address: string): Promise<bigint> {
+  try {
+    const response = await fetch(
+      `${API_URL}/program/${USDCX_PROGRAM_ID}/mapping/balances/${address}`
+    );
+    if (!response.ok) return 0n;
+    const data = await response.text();
     const cleaned = data.replace(/^"|"$/g, "");
     return parseAleoValue(cleaned);
   } catch {
@@ -333,23 +351,26 @@ export function calculatePayout(
   return (betAmount * netPool) / winningPool;
 }
 
-/** Format microcredits (bigint) to a human-readable credits string. */
-export function formatCredits(microcredits: bigint): string {
-  const credits = Number(microcredits) / 1_000_000;
-  return credits.toLocaleString(undefined, {
+/** Format micro-USDC (bigint) to a human-readable USDC string. */
+export function formatUSDC(microUsdc: bigint): string {
+  const usdc = Number(microUsdc) / 1_000_000;
+  return usdc.toLocaleString(undefined, {
     minimumFractionDigits: 2,
-    maximumFractionDigits: 6,
-  });
+    maximumFractionDigits: 2,
+  }) + ' USDC';
 }
 
-/** Format pool value for compact display (e.g., "1.2k credits"). */
-export function formatPool(microcredits: bigint): string {
-  if (microcredits === 0n) return "0";
-  const credits = Number(microcredits) / 1_000_000;
-  if (credits >= 1000) {
-    return `${(credits / 1000).toFixed(1)}k`;
+/** @deprecated Use formatUSDC instead. */
+export const formatCredits = formatUSDC;
+
+/** Format pool value for compact display (e.g., "$1.2k"). */
+export function formatPool(microUsdc: bigint): string {
+  if (microUsdc === 0n) return "$0";
+  const usdc = Number(microUsdc) / 1_000_000;
+  if (usdc >= 1000) {
+    return `$${(usdc / 1000).toFixed(1)}k`;
   }
-  return credits.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  return `$${usdc.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
 }
 
 /** Check if the deployed contract supports oracle-based resolution. */

--- a/frontend/src/pages/MarketDetailPage.tsx
+++ b/frontend/src/pages/MarketDetailPage.tsx
@@ -9,7 +9,7 @@ import { ClaimModal } from "../components/ClaimModal";
 import { RefundModal } from "../components/RefundModal";
 import { ResolveModal } from "../components/OracleResolveModal";
 import {
-  formatCredits,
+  formatUSDC,
   formatPool,
   MarketStatus,
   getMarketData,
@@ -233,7 +233,7 @@ export function MarketDetailPage() {
               <>
                 <div className="flex items-baseline justify-between mb-3 sm:mb-4">
                   <h2 className="text-xs sm:text-sm font-bold text-gray-400 uppercase tracking-wider">Probability</h2>
-                  <span className="text-[11px] sm:text-xs text-gray-600 font-mono">{totalPoolFormatted} credits in pool</span>
+                  <span className="text-[11px] sm:text-xs text-gray-600 font-mono">{totalPoolFormatted} in pool</span>
                 </div>
 
                 {/* Large probability display — only for non-open markets */}
@@ -255,8 +255,8 @@ export function MarketDetailPage() {
                 </div>
 
                 <div className="flex justify-between text-xs text-gray-500 font-mono">
-                  <span>YES: {formatPool(BigInt(market.yesPool))} credits</span>
-                  <span>NO: {formatPool(BigInt(market.noPool))} credits</span>
+                  <span>YES: {formatPool(BigInt(market.yesPool))}</span>
+                  <span>NO: {formatPool(BigInt(market.noPool))}</span>
                 </div>
               </>
             )}
@@ -305,7 +305,7 @@ export function MarketDetailPage() {
                     Hidden
                   </span>
                 ) : (
-                  <span className="text-white font-mono">{formatCredits(BigInt(totalPool))} credits</span>
+                  <span className="text-white font-mono">{formatUSDC(BigInt(totalPool))}</span>
                 )}
               </div>
               {market.endTime && (
@@ -475,13 +475,13 @@ export function MarketDetailPage() {
                     <div className="text-center py-3 rounded-md bg-navy-900 border-2 border-navy-600">
                       <div className="text-xs text-gray-500 mb-1">YES</div>
                       <div className="text-emerald-400 font-mono text-lg font-bold">
-                        {userPosition.yesAmount > 0n ? formatCredits(userPosition.yesAmount) : "-"}
+                        {userPosition.yesAmount > 0n ? formatUSDC(userPosition.yesAmount) : "-"}
                       </div>
                     </div>
                     <div className="text-center py-3 rounded-md bg-navy-900 border-2 border-navy-600">
                       <div className="text-xs text-gray-500 mb-1">NO</div>
                       <div className="text-rose-400 font-mono text-lg font-bold">
-                        {userPosition.noAmount > 0n ? formatCredits(userPosition.noAmount) : "-"}
+                        {userPosition.noAmount > 0n ? formatUSDC(userPosition.noAmount) : "-"}
                       </div>
                     </div>
                   </div>

--- a/frontend/supabase/functions/index-markets/index.ts
+++ b/frontend/supabase/functions/index-markets/index.ts
@@ -7,7 +7,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const API_URL = "https://api.explorer.provable.com/v1/testnet";
-const PROGRAM_ID = "prediction_market_test007.aleo";
+const PROGRAM_ID = "prediction_market_usdcx_v1.aleo";
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
@@ -176,7 +176,7 @@ async function scanBetTransactions(lastHeight: number): Promise<{ events: BetEve
           // Format: { program_id: ..., function_name: place_bet, arguments: [market_id, outcome, amount, {nested_future}] }
           const marketMatch = futureValue.match(/arguments:\s*\[\s*(\d+field)/);
           const outcomeMatch = futureValue.match(/arguments:\s*\[\s*\d+field,\s*(true|false)/);
-          const amountMatch = futureValue.match(/arguments:\s*\[\s*\d+field,\s*(?:true|false),\s*(\d+)u64/);
+          const amountMatch = futureValue.match(/arguments:\s*\[\s*\d+field,\s*(?:true|false),\s*(\d+)u128/);
 
           if (!marketMatch || !outcomeMatch || !amountMatch) continue;
 


### PR DESCRIPTION
## Wave 3: Replace credits.aleo with USDCx

### Contract Changes
- **Program**: `prediction_market_usdcx_v1.aleo` (new deployment needed)
- **Import**: `test_usdcx_stablecoin.aleo` (official Circle USDCx on Aleo testnet)
- **All amount types**: `u64` → `u128` (USDCx uses u128)
- **USDC tiers**: $1, $5, $10, $50, $100 (6-decimal micro-USDC)
- **Transfer calls**: `credits.aleo/*` → `test_usdcx_stablecoin.aleo/*`
- **Pedersen commitments**: verified compatible with u128 scalars
- **Dependencies**: full USDCx chain (merkle_tree + multisig_core + freezelist + stablecoin)

### Frontend Changes
- New `getUsdcxBalance()` + `formatUSDC()` utilities
- Dual balance display (USDC + credits for gas)
- All labels: 'credits' → 'USDC' / dollar formatting
- Tier selector: $1/$5/$10/$50/$100
- Amount parsing updated for u128

### What's NOT changing
- Counter types stay u64 (market_count, bet_count, dispute_count)
- Block heights stay u32
- Pedersen commitment math (m*G + r*H works with u128→scalar)
- Oracle integration (official_oracle_v2.aleo)

### Deploy Notes
1. New contract deployment required (`prediction_market_usdcx_v1.aleo`)
2. Get test USDCx from Arcane Finance faucet
3. Users need BOTH USDCx (for bets) and Aleo credits (for gas)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USDCx stablecoin support with dual-balance display (USDC + gas)

* **Enhancements**
  * All monetary displays and formatting updated to USDC with dollar-sign notation
  * Bet tiers and default selection realigned to USDC denominations
  * Increased numeric precision to support larger USDCx-denominated amounts
  * Parallel balance fetching and improved UI balance handling

* **Bug Fixes**
  * Parsing updated to correctly handle larger on-chain amount encodings

* **Tests**
  * Test expectations updated for USDC formatting and program identifier
<!-- end of auto-generated comment: release notes by coderabbit.ai -->